### PR TITLE
Escape dot in key of meta-tag identifier

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -1028,6 +1028,7 @@ meta
                    og:site_name = TYPO3
                    og:site_name.attribute = property
                    description = Inspiring people to share Normal
+                   dc\.description = Inspiring people to share [DC tags]
                    og:description = Inspiring people to share [OpenGraph]
                    og:description.attribute = property
                    og:locale = en_GB


### PR DESCRIPTION
Dots have to be escaped, otherwise, the property will be ignored (To be exact: parsed TS could not be rendered in a correct way).